### PR TITLE
Change repository url from SSH to HTTPS

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/heremaps/harp-fontcatalog.git"
+    "url": "https://github.com/heremaps/harp-fontcatalog.git"
   },
   "author": {
     "name": "HERE Europe B.V.",


### PR DESCRIPTION
Using HTTPS allows users to clone the repository using
tools like OSS Review Toolkit without authentication.