### PR TITLE
Move harp-fontcatalog-generator to devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "npm": ">=5.8.0",
     "yarn": ">=1.11.1"
   },
-  "dependencies": {
+  "devDependencies": {
     "@here/harp-fontcatalog-generator": "^0.1.3"
   }
 }


### PR DESCRIPTION
`harp-fontcatalog` is "compiled" package and it shouldn't bring all the dev tools into installations.